### PR TITLE
Add windows cr

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ require("lazy").setup({
 <!-- > **Note:**
 > For Please see below for Windows installation instructions -->
 
-Windows installations need to be adjusted to utilize PowerShell. This can be accomplished by changing the `do`/`run`/`build` parameter in your plugin manager's configuration from: `"./dl_binaries.sh"` to: `"pwsh.exe -file .\\dl_binaries.ps1"`
+Windows installations need to be adjusted to utilize PowerShell. This can be accomplished by changing the `do/run/build` parameter in your plugin manager's configuration from: `./dl_binaries.sh` to `pwsh.exe -file .\\dl_binaries.ps"`
 
 ```Lua
 -- Example using lazy.nvim

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ require("lazy").setup({
 <!-- > **Note:**
 > For Please see below for Windows installation instructions -->
 
-Windows installations need to be adjusted to utilize PowerShell. This can be accomplished by changing the `do/run/build` parameter in your plugin manager's configuration from: `./dl_binaries.sh` to `pwsh.exe -file .\\dl_binaries.ps"`
+Windows installations need to be adjusted to utilize PowerShell. This can be accomplished by changing the `do/run/build` parameter in your plugin manager's configuration from: `./dl_binaries.sh` to `pwsh.exe -file .\\dl_binaries.ps1"`
 
 ```Lua
 -- Example using lazy.nvim

--- a/dl_binaries.ps1
+++ b/dl_binaries.ps1
@@ -5,10 +5,7 @@
 $version = invoke-webrequest -uri 'https://update.tabnine.com/bundles/version' -usebasicparsing
 $targets = @(
     'i686-pc-windows-gnu'
-    'x86_64-apple-darwin'
     'x86_64-pc-windows-gnu'
-    'x86_64-unknown-linux-musl'
-    'aarch64-apple-darwin'
 )
 
 if (test-path -path "binaries/$version") {

--- a/dl_binaries.sh
+++ b/dl_binaries.sh
@@ -4,9 +4,7 @@ set -e
 # This script downloads the binaries for the most recent version of TabNine.
 
 version="$(curl -sS https://update.tabnine.com/bundles/version)"
-targets='i686-pc-windows-gnu
-    x86_64-apple-darwin
-    x86_64-pc-windows-gnu
+targets='x86_64-apple-darwin
     x86_64-unknown-linux-musl
     aarch64-apple-darwin'
 

--- a/lua/tabnine/binary.lua
+++ b/lua/tabnine/binary.lua
@@ -32,7 +32,7 @@ local function binary_name()
 	if os_uname.sysname == "Windows_NT" then
 		return "TabNine.exe"
 	else
-		return "/TabNine"
+		return "TabNine"
 	end
 end
 
@@ -47,7 +47,7 @@ local function binary_path()
 
 	table.sort(paths)
 
-	return binaries_path .. "/" .. tostring(paths[#paths]) .. "/" .. arch_and_platform() .. binary_name()
+	return binaries_path .. "/" .. tostring(paths[#paths]) .. "/" .. arch_and_platform() .. "/" .. binary_name()
 end
 
 function TabnineBinary:start()

--- a/lua/tabnine/binary.lua
+++ b/lua/tabnine/binary.lua
@@ -11,8 +11,6 @@ json.encode_empty_table_as_object(true)
 local api_version = "4.4.71"
 local binaries_path = utils.script_path() .. "../../binaries"
 
-os.is_win = package.config:sub(1, 1) == "\\"
-
 local function arch_and_platform()
 	local os_uname = uv.os_uname()
 
@@ -22,13 +20,19 @@ local function arch_and_platform()
 		return "aarch64-apple-darwin"
 	elseif os_uname.sysname == "Darwin" then
 		return "x86_64-apple-darwin"
-	elseif fn.has("win32") then
-		local arch = os.getenv"PROCESSOR_ARCHITECTURE"
-		if (arch or ""):match"64" then
-			return "x86_64-pc-windows-gnu"
-		else
-			return "i686-pc-windows-gnu"
-		end
+	elseif os_uname.sysname == "Windows_NT" and os_uname.machine == "x86_64" then
+		return "x86_64-pc-windows-gnu"
+	elseif os_uname.sysname == "Windows_NT" then
+		return "i686-pc-windows-gnu"
+	end
+end
+
+local function binary_name()
+	local os_uname = uv.os_uname()
+	if os_uname.sysname == "Windows_NT" then
+		return "TabNine.exe"
+	else
+		return "/TabNine"
 	end
 end
 
@@ -43,14 +47,7 @@ local function binary_path()
 
 	table.sort(paths)
 
-	local binary_name
-	if os.is_win then
-		binary_name = "/TabNine.exe"
-	else
-		binary_name = "/TabNine"
-	end
-
-	return binaries_path .. "/" .. tostring(paths[#paths]) .. "/" .. arch_and_platform() .. binary_name
+	return binaries_path .. "/" .. tostring(paths[#paths]) .. "/" .. arch_and_platform() .. binary_name()
 end
 
 function TabnineBinary:start()

--- a/lua/tabnine/utils.lua
+++ b/lua/tabnine/utils.lua
@@ -2,7 +2,6 @@ local fn = vim.fn
 local api = vim.api
 
 local M = {}
-
 function M.str_to_lines(str)
 	return fn.split(str, "\n")
 end


### PR DESCRIPTION
Hi @instance-id, highly appreciate the PR and sorry for the late reply.

See my adjustments here and let me know if you're okay with it.

I've tried to run the `dl_binaries.ps1`  script on a colleague Windows machine and got this error. Any idea? unfortunately I don't have time to investigate this:
```powershell
Expand-Archive : A parameter cannot be found that matches parameter name 'outputpath'.
At C:\Users\tzufs\AppData\Local\nvim-data\site\pack\packer\start\tabnine-nvim\dl_binaries.ps1:27 char:55
+ ... expand-archive -path "binaries/$path/TabNine.zip" -outputpath "binari ...
+                                                       ~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Expand-Archive], ParameterBindingException
    + FullyQualifiedErrorId : NamedParameterNotFound,Expand-Archive
```

![image](https://user-images.githubusercontent.com/7681048/224539957-9d1e90ed-c53f-489e-bde1-5cf94a936479.png)
